### PR TITLE
Remove unused "colors" dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 var fs   = require('fs'),
   Path   = require('path'),
   util   = require('util'),
-  colors = require('colors'),
   EE     = require('events').EventEmitter,
   fsExists = fs.exists ? fs.exists : Path.exists,
   fsExistsSync = fs.existsSync ? fs.existsSync : Path.existsSync;

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "test": "mocha ./test/*.js"
   },
   "dependencies": {
-    "colors": "~0.6.0-1",
     "commander": "~2.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR removes the unused `colors` dependency from `package.json` and the `index.js` file