### PR TITLE
bin: Fix dir option so it actually works

### DIFF
--- a/bin/findup.js
+++ b/bin/findup.js
@@ -30,7 +30,7 @@ if(!options.name) {
 
 var file = options.name;
 
-findup(process.cwd(), file, options, function(err, dir){
+findup(options.dir, file, options, function(err, dir){
   if(err) return console.error(err.message ? err.message : err);
   console.log(path.join(dir, file));
 });


### PR DESCRIPTION
Previously, it only finds up from current working directory. This makes sure that the `--dir` flag works.

