### PR TITLE
maxdepth support - Add option to traverse a directory a limited depth…

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,14 @@ Find up a file in ancestor's dir
                     │   └── a
                     └── config.json
 
+### Options
+
+- `maxdepth`: (Number, default -1) How far to traverse before giving up. If maxdepth is `-1`, then there is no limit.
+
 #### Async
 
-findup(dir, fileName, callback)
-findup(dir, iterator, callback) with `iterator(dir, cb)` where cb only accept `true` or `false`
+findup(dir, fileName, options, callback)
+findup(dir, iterator, options, callback) with `iterator(dir, cb)` where cb only accept `true` or `false`
 
 ```js
 var findup = require('findup');
@@ -51,14 +55,14 @@ findup(__dirname + '/f/e/d/c/b/a', function(dir, cb){
 
 #### EventEmitter
 
-findup(dir, fileName)
+findup(dir, fileName, options)
 
 ```js
 var findup = require('findup');
 var fup = findup(__dirname + '/f/e/d/c/b/a', 'config.json');
 ```
 
-findup(dir, iterator) with `iterator(dir, cb)` where cb only accept `true` or `false`
+findup(dir, iterator, options) with `iterator(dir, cb)` where cb only accept `true` or `false`
 
 ```js
 var findup = require('findup');

--- a/bin/findup.js
+++ b/bin/findup.js
@@ -5,18 +5,23 @@ var findup = require('..'),
   pkg = require('../package'),
   program = require('commander'),
   options = {},
-  optionKeys = ['name', 'dir', 'verbose'],
+  optionKeys = ['name', 'dir', 'maxdepth', 'verbose'],
   EXIT_FAILURE = -1;
   
   program
     .version(pkg.version)
     .option('--name <name>', 'The name of the file to find', String)
     .option('--dir <dir>', 'The directoy where we will start walking up', process.cwd(), path)
+    .option('--maxdepth <levels>', 'Ascend at most <levels> levels before giving up. -1 means no limit', -1, Number)
     .option('--verbose', 'print log', false, Boolean)
     .parse(process.argv);
 
 optionKeys.forEach(function(optionKey){
-  options[optionKey] = program[optionKey];
+  if (optionKey === 'maxdepth') {
+    options[optionKey] = +program[optionKey];
+  } else {
+    options[optionKey] = program[optionKey];
+  }
 });
 
 if(program.args && program.args.length >=1 && !options.name){

--- a/test/findup-test.js
+++ b/test/findup-test.js
@@ -106,5 +106,59 @@ describe('find-up', function(){
         findup.sync('uhjhbjkg,nfg', 'toto.json');
       });
     });
+
+    it('should work with maxdepth (top, maxdepth 0)', function(){
+      var file = findup.sync(fixtureDir, 'top.json', {maxdepth: 0});
+      assert.equal(file, Path.join(__dirname, 'fixture', 'f', 'e', 'd', 'c', 'b', 'a'));
+    });
+
+    it('should work with maxdepth (config, maxdepth 0)', function(){
+      try {
+        findup.sync(fixtureDir, 'config.json', {maxdepth: 0});
+      } catch (err) {
+        assert.equal(err.message, 'not found');
+      }
+    });
+
+    it('should work with maxdepth (config, maxdepth 2)', function(){
+      var file = findup.sync(fixtureDir, 'config.json', {maxdepth: 2});
+      assert.equal(file, Path.join(__dirname, 'fixture', 'f', 'e', 'd', 'c'));
+    });
+
+    it('should work with maxdepth (config, maxdepth -1)', function(){
+      var file = findup.sync(fixtureDir, 'config.json', {maxdepth: -1});
+      assert.equal(file, Path.join(__dirname, 'fixture', 'f', 'e', 'd', 'c'));
+    });
+  });
+
+  it('should work with maxdepth (top, maxdepth 0)', function(done){
+    findup(fixtureDir, 'top.json', {maxdepth: 0}, function(err, file){
+      assert.ifError(err);
+      assert.equal(file, Path.join(__dirname, 'fixture', 'f', 'e', 'd', 'c', 'b', 'a'));
+      done();
+    });
+  });
+
+  it('should work with maxdepth (config, maxdepth 0)', function(done){
+    findup(fixtureDir, 'config.json', {maxdepth: 0}, function(err, file){
+      assert.equal(err.message, 'not found');
+      done();
+    });
+  });
+
+  it('should work with maxdepth (config, maxdepth 2)', function(done){
+    findup(fixtureDir, 'config.json', {maxdepth: 2}, function(err, file){
+      assert.ifError(err);
+      assert.equal(file, Path.join(__dirname, 'fixture', 'f', 'e', 'd', 'c'));
+      done();
+    });
+  });
+
+  it('should work with maxdepth (config, maxdepth -1)', function(done){
+    findup(fixtureDir, 'config.json', {maxdepth: -1}, function(err, file){
+      assert.ifError(err);
+      assert.equal(file, Path.join(__dirname, 'fixture', 'f', 'e', 'd', 'c'));
+      done();
+    });
   });
 });


### PR DESCRIPTION
… before giving up.

This is done via existing parameter on the async API, and a new parameter on the sync API -- `options`.

- Max depth of -1 means that there is no limit, and it will search as if the max depth option was not set.
- Max depth of 0 means that it will only look in the directory the file we're searching from is in, but no further.
- Max depth of 1 means that it will look in the directory of max depth 0, and the directory before that.

etc.