### PR TITLE
Fix endless loop on windows with Finup.sync

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,14 +93,14 @@ module.exports.sync = function(dir, iteratorSync, options){
   options = options || {};
   var initialDir = dir;
   var currentDepth = 0;
-  while(dir !== Path.join(dir, '..')){
+  while(dir !== Path.resolve(dir, '..')){
     if (typeof options.maxdepth === 'number' && options.maxdepth >= 0 && currentDepth > options.maxdepth) {
       break
     }
     currentDepth++;
     if(dir.indexOf('../../') !== -1 ) throw new Error(initialDir + ' is not correct.');
     if(iteratorSync(dir)) return dir;
-    dir = Path.join(dir, '..');
+    dir = Path.resolve(dir, '..');
   }
   throw new Error('not found');
 };

--- a/index.js
+++ b/index.js
@@ -93,14 +93,16 @@ module.exports.sync = function(dir, iteratorSync, options){
   options = options || {};
   var initialDir = dir;
   var currentDepth = 0;
-  while(dir !== Path.resolve(dir, '..')){
+  var parentDir = Path.resolve(dir, '..');
+  while(dir !== parentDir){
     if (typeof options.maxdepth === 'number' && options.maxdepth >= 0 && currentDepth > options.maxdepth) {
       break
     }
     currentDepth++;
     if(dir.indexOf('../../') !== -1 ) throw new Error(initialDir + ' is not correct.');
     if(iteratorSync(dir)) return dir;
-    dir = Path.resolve(dir, '..');
+    dir = parentDir;
+    parentDir = Path.resolve(dir, '..');
   }
   throw new Error('not found');
 };


### PR DESCRIPTION
Not sure if this is the correct fix, but I guess Path.join and Path.resolve should behave pretty much the same, but the later will return a normalized absolute paths and make sure excessive `..` references are removed. It might be enough to use `Path.normalize(Path.join(...))` inside the loop, but the [documentation](https://nodejs.org/api/path.html#path_path_resolve_paths) for these functions is a bit incomplete for my taste. They i.e. do not carify if [symbolic links will be resolved](https://nodejs.org/api/fs.html#fs_fs_realpath_path) or not (I guess it's just a logical path cleanup from cwd). So this should work AFAICS.
