### PR TITLE
Whitelist of files for npm to package

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,5 +30,10 @@
       "type": "MIT",
       "url": "http  : //www.opensource.org/licenses/MIT"
     }
+  ],
+  "files": [
+    "bin/findup.js",
+    "index.js",
+    "README.md"
   ]
 }


### PR DESCRIPTION
Following on from #21 

This should prevent files that are not required "for use" being included when uploading to npm.